### PR TITLE
adicionando payment_gateway_id ao retorno

### DIFF
--- a/lib/VotoLegal/Controller/API/Candidate.pm
+++ b/lib/VotoLegal/Controller/API/Candidate.pm
@@ -91,7 +91,7 @@ sub candidate_GET {
             map { $_ => $c->stash->{candidate}->$_ } qw(
               id name popular_name status reelection party_id office_id status username picture
               video_url facebook_url twitter_url website_url summary biography instagram_url cnpj
-              raising_goal public_email spending_spreadsheet address_city address_state
+              raising_goal public_email spending_spreadsheet address_city address_state payment_gateway_id
             )
         };
     }


### PR DESCRIPTION
Adicionar o payment_gateway_id para que no front-end possa visualizar qual payment gateway deve ser utilizado.